### PR TITLE
Revert "klte-common: enable sdcardfs overlay"

### DIFF
--- a/system_prop.mk
+++ b/system_prop.mk
@@ -37,10 +37,6 @@ PRODUCT_PROPERTY_OVERRIDES += \
     ro.qc.sdk.izat.premium_enabled=0 \
     ro.qc.sdk.izat.service_mask=0x0
 
-# Misc
-PRODUCT_PROPERTY_OVERRIDES += \
-    ro.sdcardfs.enable=true
-
 # NFC
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.nfc.port=I2C


### PR DESCRIPTION
This reverts commit 933fe28b6256c8cce55c488befb44150e06da48a.

This patch introduces a permission regression.

With this patch, only root is able to write to the
external SD card.  Reverting this patch re-enables
writing for all apps (into their respective dirs).

Change-Id: Id060821c52661643739806c9d2186710e234727f
